### PR TITLE
MOBILE-1264_part3: Finish bank/card payment flow

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,21 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="eu.kevin.inapppayments.paymentsession.PaymentSessionActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="redirect.payment"
+                    android:scheme="kevin" />
+            </intent-filter>
+        </activity>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/example/data/lib/kevin/api/kevin_api_client.dart
+++ b/example/data/lib/kevin/api/kevin_api_client.dart
@@ -1,0 +1,31 @@
+import 'package:data/kevin/entity/payment_entity.dart';
+import 'package:data/kevin/entity/payment_request_entity.dart';
+import 'package:dio/dio.dart';
+import 'package:domain/kevin/model/payment.dart';
+import 'package:domain/kevin/model/payment_request.dart';
+
+class KevinApiClient {
+  final Dio _dio;
+
+  const KevinApiClient({
+    required Dio dio,
+  }) : _dio = dio;
+
+  Future<Payment> initializeBankPayment(PaymentRequest request) =>
+      _initializePayment(path: 'payments/bank/', request: request);
+
+  Future<Payment> initializeCardPayment(PaymentRequest request) =>
+      _initializePayment(path: 'payments/card/', request: request);
+
+  Future<Payment> _initializePayment({
+    required String path,
+    required PaymentRequest request,
+  }) async {
+    final result = await _dio.post(
+      path,
+      data: PaymentRequestEntity.fromModel(request).toJson(),
+    );
+
+    return PaymentEntity.fromJson(result.data).toModel();
+  }
+}

--- a/example/data/lib/kevin/entity/payment_entity.dart
+++ b/example/data/lib/kevin/entity/payment_entity.dart
@@ -1,0 +1,18 @@
+import 'package:domain/kevin/model/payment.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'payment_entity.g.dart';
+
+@JsonSerializable(createToJson: false)
+class PaymentEntity {
+  final String id;
+
+  const PaymentEntity({
+    required this.id,
+  });
+
+  factory PaymentEntity.fromJson(Map<String, dynamic> json) =>
+      _$PaymentEntityFromJson(json);
+
+  Payment toModel() => Payment(id: id);
+}

--- a/example/data/lib/kevin/entity/payment_entity.g.dart
+++ b/example/data/lib/kevin/entity/payment_entity.g.dart
@@ -1,0 +1,12 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'payment_entity.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PaymentEntity _$PaymentEntityFromJson(Map<String, dynamic> json) =>
+    PaymentEntity(
+      id: json['id'] as String,
+    );

--- a/example/data/lib/kevin/entity/payment_request_entity.dart
+++ b/example/data/lib/kevin/entity/payment_request_entity.dart
@@ -1,0 +1,32 @@
+import 'package:domain/kevin/model/payment_request.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'payment_request_entity.g.dart';
+
+@JsonSerializable(createFactory: false)
+class PaymentRequestEntity {
+  final String amount;
+  final String email;
+  final String creditorName;
+  final String redirectUrl;
+  final String? iban;
+
+  const PaymentRequestEntity({
+    required this.amount,
+    required this.email,
+    required this.creditorName,
+    required this.redirectUrl,
+    this.iban,
+  });
+
+  Map<String, dynamic> toJson() => _$PaymentRequestEntityToJson(this);
+
+  factory PaymentRequestEntity.fromModel(PaymentRequest request) =>
+      PaymentRequestEntity(
+        amount: request.amount,
+        email: request.email,
+        creditorName: request.creditorName,
+        redirectUrl: request.redirectUrl,
+        iban: request.iban,
+      );
+}

--- a/example/data/lib/kevin/entity/payment_request_entity.g.dart
+++ b/example/data/lib/kevin/entity/payment_request_entity.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'payment_request_entity.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$PaymentRequestEntityToJson(
+        PaymentRequestEntity instance) =>
+    <String, dynamic>{
+      'amount': instance.amount,
+      'email': instance.email,
+      'creditorName': instance.creditorName,
+      'redirectUrl': instance.redirectUrl,
+      'iban': instance.iban,
+    };

--- a/example/data/lib/kevin/repository/network_kevin_repository.dart
+++ b/example/data/lib/kevin/repository/network_kevin_repository.dart
@@ -1,0 +1,20 @@
+import 'package:data/kevin/api/kevin_api_client.dart';
+import 'package:domain/kevin/model/payment.dart';
+import 'package:domain/kevin/model/payment_request.dart';
+import 'package:domain/kevin/repository/kevin_repository.dart';
+
+class NetworkKevinRepository extends KevinRepository {
+  final KevinApiClient _apiClient;
+
+  NetworkKevinRepository({
+    required KevinApiClient apiClient,
+  }) : _apiClient = apiClient;
+
+  @override
+  Future<Payment> initializeBankPayment(PaymentRequest request) =>
+      _apiClient.initializeBankPayment(request);
+
+  @override
+  Future<Payment> initializeCardPayment(PaymentRequest request) =>
+      _apiClient.initializeCardPayment(request);
+}

--- a/example/data/pubspec.lock
+++ b/example/data/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -98,7 +98,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -112,7 +119,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -175,7 +182,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   file:
     dependency: transitive
     description:
@@ -290,21 +297,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -325,7 +332,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   pool:
     dependency: transitive
     description:
@@ -386,7 +393,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -414,21 +421,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:
@@ -472,4 +479,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.1 <3.0.0"
+  dart: ">=2.17.6 <3.0.0"

--- a/example/data/pubspec.yaml
+++ b/example/data/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
   flutter:

--- a/example/domain/lib/kevin/model/payment.dart
+++ b/example/domain/lib/kevin/model/payment.dart
@@ -1,0 +1,12 @@
+import 'package:equatable/equatable.dart';
+
+class Payment extends Equatable {
+  final String id;
+
+  const Payment({
+    required this.id,
+  });
+
+  @override
+  List<Object?> get props => [id];
+}

--- a/example/domain/lib/kevin/model/payment_request.dart
+++ b/example/domain/lib/kevin/model/payment_request.dart
@@ -1,0 +1,26 @@
+import 'package:equatable/equatable.dart';
+
+class PaymentRequest extends Equatable {
+  final String amount;
+  final String email;
+  final String creditorName;
+  final String redirectUrl;
+  final String? iban;
+
+  const PaymentRequest({
+    required this.amount,
+    required this.email,
+    required this.creditorName,
+    required this.redirectUrl,
+    this.iban,
+  });
+
+  @override
+  List<Object?> get props => [
+        amount,
+        email,
+        creditorName,
+        redirectUrl,
+        iban,
+      ];
+}

--- a/example/domain/lib/kevin/repository/kevin_repository.dart
+++ b/example/domain/lib/kevin/repository/kevin_repository.dart
@@ -1,0 +1,8 @@
+import 'package:domain/kevin/model/payment.dart';
+import 'package:domain/kevin/model/payment_request.dart';
+
+abstract class KevinRepository {
+  Future<Payment> initializeBankPayment(PaymentRequest request);
+
+  Future<Payment> initializeCardPayment(PaymentRequest request);
+}

--- a/example/domain/pubspec.lock
+++ b/example/domain/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   collection:
     dependency: "direct main"
     description:
@@ -49,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,28 +87,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +141,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
@@ -157,4 +164,4 @@ packages:
     source: hosted
     version: "2.1.2"
 sdks:
-  dart: ">=2.18.1 <3.0.0"
+  dart: ">=2.17.6 <3.0.0"

--- a/example/domain/pubspec.yaml
+++ b/example/domain/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
   flutter:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -32,7 +32,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   kevin-ios: 143e5fc1f2fb8b24829c0b80f4bcb60af3d5f769
   kevin_flutter_core_ios: c64936e82cb1fa7dcd67af7cddc764019b06d05e
   kevin_flutter_in_app_payments: 6f3baa40dc06987ef6762b115e05ac46b073b2e8

--- a/example/lib/common_widgets/kevin_dialog.dart
+++ b/example/lib/common_widgets/kevin_dialog.dart
@@ -1,0 +1,133 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class KevinDialog extends StatelessWidget {
+  final String? _title;
+  final String? _content;
+  final List<KevinDialogAction> _actions;
+
+  const KevinDialog({
+    super.key,
+    required List<KevinDialogAction> actions,
+    String? title,
+    String? content,
+  })  : _actions = actions,
+        _title = title,
+        _content = content;
+
+  @override
+  Widget build(BuildContext context) {
+    if (Platform.isIOS) {
+      return _CupertinoKevinDialog(
+        title: _title,
+        content: _content,
+        actions: _actions,
+      );
+    }
+
+    return _MaterialKevinDialog(
+      title: _title,
+      content: _content,
+      actions: _actions,
+    );
+  }
+}
+
+class KevinDialogAction extends StatelessWidget {
+  final String _text;
+  final VoidCallback? _onPressed;
+
+  const KevinDialogAction({
+    super.key,
+    required String text,
+    required VoidCallback? onPressed,
+  })  : _text = text,
+        _onPressed = onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    if (Platform.isIOS) {
+      return CupertinoDialogAction(
+        onPressed: _onPressed,
+        child: Text(_text),
+      );
+    }
+
+    return TextButton(onPressed: _onPressed, child: Text(_text));
+  }
+}
+
+class _MaterialKevinDialog extends StatelessWidget {
+  final String? _title;
+  final String? _content;
+  final List<KevinDialogAction> _actions;
+
+  const _MaterialKevinDialog({
+    required String? title,
+    required String? content,
+    required List<KevinDialogAction> actions,
+  })  : _title = title,
+        _content = content,
+        _actions = actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleWidget = _title != null ? Text(_title!) : null;
+    final contentWidget = _content != null ? Text(_content!) : null;
+
+    return AlertDialog(
+      title: titleWidget,
+      content: contentWidget,
+      actions: _actions,
+      actionsOverflowDirection: VerticalDirection.up,
+    );
+  }
+}
+
+class _CupertinoKevinDialog extends StatelessWidget {
+  final String? _title;
+  final String? _content;
+  final List<KevinDialogAction> _actions;
+
+  const _CupertinoKevinDialog({
+    required String? title,
+    required String? content,
+    required List<KevinDialogAction> actions,
+  })  : _title = title,
+        _content = content,
+        _actions = actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleWidget = _title != null ? Text(_title!) : null;
+    final contentWidget = _content != null ? Text(_content!) : null;
+
+    return CupertinoAlertDialog(
+      title: titleWidget,
+      content: contentWidget,
+      actions: _actions,
+    );
+  }
+}
+
+Future<T?> showKevinDialog<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool dismissible = true,
+}) {
+  if (Platform.isIOS) {
+    return showCupertinoDialog(
+      context: context,
+      builder: builder,
+      barrierDismissible: dismissible,
+    );
+  }
+
+  return showDialog(
+    context: context,
+    builder: builder,
+    barrierDismissible: dismissible,
+  );
+}

--- a/example/lib/country/country_extensions.dart
+++ b/example/lib/country/country_extensions.dart
@@ -1,0 +1,12 @@
+import 'package:collection/collection.dart';
+import 'package:domain/country/model/country.dart';
+import 'package:kevin_flutter_core/kevin_flutter_core.dart';
+
+extension ToKevinCountry on Country {
+  KevinCountry toKevinCountry({required KevinCountry defaultCountry}) {
+    final country = KevinCountry.values
+        .firstWhereOrNull((c) => c.iso == code.toLowerCase());
+
+    return country ?? defaultCountry;
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 
+import 'package:data/kevin/api/kevin_api_client.dart';
+import 'package:data/kevin/repository/network_kevin_repository.dart';
 import 'package:data/payments/api/payments_data_api_client.dart';
 import 'package:data/payments/repository/network_payments_data_repository.dart';
 import 'package:dio/dio.dart';
 import 'package:domain/country/country_helper.dart';
+import 'package:domain/kevin/repository/kevin_repository.dart';
 import 'package:domain/payments/repository/payments_data_repository.dart';
 import 'package:domain/payments/usecase/get_creditors_use_case.dart';
 import 'package:domain/payments/usecase/get_supported_countries_use_case.dart';
@@ -12,15 +15,20 @@ import 'package:fimber/fimber.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:kevin_flutter_core/kevin_flutter_core.dart';
 import 'package:kevin_flutter_example/analytics/bloc_error_observer.dart';
 import 'package:kevin_flutter_example/app/widget/app.dart';
 import 'package:kevin_flutter_example/country/local_resources_country_helper.dart';
 import 'package:kevin_flutter_example/error/api_error_mapper.dart';
 import 'package:kevin_flutter_example/validation/amount_validator.dart';
 import 'package:kevin_flutter_example/validation/email_validator.dart';
+import 'package:kevin_flutter_in_app_payments/kevin_flutter_in_app_payments.dart';
 
 const _defaultTimeOutDuration = 120000;
 const _kevinApiUrl = 'https://api.getkevin.eu/demo/';
+const _kevinMobileDemoApiUrl = 'https://mobile-demo.kevin.eu/api/v1/';
+
+const _kevinPaymentsCallbackUrl = 'kevin://redirect.payment';
 
 void main() {
   runZonedGuarded(() async {
@@ -42,8 +50,14 @@ void main() {
       );
     };
 
+    await _initKevinSdk();
+
     final kevinApiClient = await _httpClient(
       baseUrl: _kevinApiUrl,
+      enableLogging: true,
+    );
+    final kevinDemoApiClient = await _httpClient(
+      baseUrl: _kevinMobileDemoApiUrl,
       enableLogging: true,
     );
 
@@ -64,6 +78,13 @@ void main() {
                 NetworkPaymentsDataRepository(apiClient: context.read()),
           ),
           RepositoryProvider(
+            create: (context) => KevinApiClient(dio: kevinDemoApiClient),
+          ),
+          RepositoryProvider<KevinRepository>(
+            create: (context) =>
+                NetworkKevinRepository(apiClient: context.read()),
+          ),
+          RepositoryProvider(
             create: (context) => GetSupportedCountriesUseCase(
               repository: context.read(),
               countryHelper: context.read(),
@@ -81,6 +102,13 @@ void main() {
   }, (error, stack) {
     Fimber.e('main() error', ex: error, stacktrace: stack);
   });
+}
+
+Future<void> _initKevinSdk() async {
+  await Kevin.setDeepLinkingEnabled(true);
+  await KevinPayments.setPaymentsConfiguration(
+    const KevinPaymentsConfiguration(callbackUrl: _kevinPaymentsCallbackUrl),
+  );
 }
 
 Future<Dio> _httpClient({

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:data/kevin/api/kevin_api_client.dart';
 import 'package:data/kevin/repository/network_kevin_repository.dart';
@@ -28,7 +29,9 @@ const _defaultTimeOutDuration = 120000;
 const _kevinApiUrl = 'https://api.getkevin.eu/demo/';
 const _kevinMobileDemoApiUrl = 'https://mobile-demo.kevin.eu/api/v1/';
 
-const _kevinPaymentsCallbackUrl = 'kevin://redirect.payment';
+// TODO: Rework after plugin supports specific ios/android callbacks
+const _kevinPaymentsCallbackUrlAndroid = 'kevin://redirect.payment';
+const _kevinPaymentsCallbackUrlIos = 'https://redirect.kevin.eu/payment.html';
 
 void main() {
   runZonedGuarded(() async {
@@ -105,9 +108,14 @@ void main() {
 }
 
 Future<void> _initKevinSdk() async {
+  // TODO: Rework after plugin supports specific ios/android callbacks
+  final callbackUrl = Platform.isIOS
+      ? _kevinPaymentsCallbackUrlIos
+      : _kevinPaymentsCallbackUrlAndroid;
+
   await Kevin.setDeepLinkingEnabled(true);
   await KevinPayments.setPaymentsConfiguration(
-    const KevinPaymentsConfiguration(callbackUrl: _kevinPaymentsCallbackUrl),
+    KevinPaymentsConfiguration(callbackUrl: callbackUrl),
   );
 }
 

--- a/example/lib/main/widget/main_page.dart
+++ b/example/lib/main/widget/main_page.dart
@@ -26,6 +26,7 @@ class MainPage extends StatefulWidget {
           ),
           BlocProvider(
             create: (context) => PaymentsBloc(
+              kevinRepository: context.read(),
               getCreditorsUseCase: context.read(),
               emailValidator: context.read(),
               amountValidator: context.read(),

--- a/example/lib/payments/model/payment_session.dart
+++ b/example/lib/payments/model/payment_session.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+import 'package:kevin_flutter_core/kevin_flutter_core.dart';
+import 'package:kevin_flutter_in_app_payments/kevin_flutter_in_app_payments.dart';
+
+class PaymentSession extends Equatable {
+  final String paymentId;
+  final KevinPaymentType paymentType;
+  final bool skipAuthentication;
+  final KevinCountry preselectedCountry;
+
+  const PaymentSession({
+    required this.paymentId,
+    required this.paymentType,
+    required this.skipAuthentication,
+    required this.preselectedCountry,
+  });
+
+  @override
+  List<Object?> get props => [
+        paymentId,
+        paymentType,
+        skipAuthentication,
+        preselectedCountry,
+      ];
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   bloc:
     dependency: transitive
     description:
@@ -35,14 +35,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   collection:
     dependency: "direct main"
     description:
@@ -91,7 +98,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   fimber:
     dependency: "direct main"
     description:
@@ -159,44 +166,44 @@ packages:
   kevin_flutter_core:
     dependency: "direct main"
     description:
-      name: kevin_flutter_core
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/kevin_flutter_core/kevin_flutter_core"
+      relative: true
+    source: path
     version: "1.0.2"
   kevin_flutter_core_android:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: kevin_flutter_core_android
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/kevin_flutter_core/kevin_flutter_core_android"
+      relative: true
+    source: path
     version: "1.0.2"
   kevin_flutter_core_ios:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: kevin_flutter_core_ios
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/kevin_flutter_core/kevin_flutter_core_ios"
+      relative: true
+    source: path
     version: "1.0.2"
   kevin_flutter_core_platform_interface:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: kevin_flutter_core_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/kevin_flutter_core/kevin_flutter_core_platform_interface"
+      relative: true
+    source: path
     version: "1.0.2"
   kevin_flutter_in_app_payments:
     dependency: "direct main"
     description:
-      name: kevin_flutter_in_app_payments
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/kevin_flutter_in_app_payments/kevin_flutter_in_app_payments"
+      relative: true
+    source: path
     version: "1.0.0"
   kevin_flutter_in_app_payments_platform_interface:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: kevin_flutter_in_app_payments_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/kevin_flutter_in_app_payments/kevin_flutter_in_app_payments_platform_interface"
+      relative: true
+    source: path
     version: "1.0.0"
   lints:
     dependency: transitive
@@ -211,21 +218,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   modal_bottom_sheet:
     dependency: "direct main"
     description:
@@ -246,7 +253,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   path_drawing:
     dependency: transitive
     description:
@@ -307,7 +314,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -335,21 +342,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -428,5 +435,5 @@ packages:
     source: hosted
     version: "6.1.0"
 sdks:
-  dart: ">=2.18.1 <3.0.0"
+  dart: ">=2.17.6 <3.0.0"
   flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=2.17.6 <3.0.0'
 
 dependencies:
   flutter:
@@ -43,8 +43,22 @@ dependencies:
   cupertino_icons: ^1.0.5
 
   # kevin. SDK plugins
-  kevin_flutter_core: ^1.0.2
-  kevin_flutter_in_app_payments: 1.0.0
+  kevin_flutter_core:
+    path: ../packages/kevin_flutter_core/kevin_flutter_core
+  kevin_flutter_in_app_payments:
+    path: ../packages/kevin_flutter_in_app_payments/kevin_flutter_in_app_payments
+
+dependency_overrides:
+  kevin_flutter_core:
+    path: ../packages/kevin_flutter_core/kevin_flutter_core
+  kevin_flutter_core_platform_interface:
+    path: ../packages/kevin_flutter_core/kevin_flutter_core_platform_interface
+  kevin_flutter_core_android:
+    path: ../packages/kevin_flutter_core/kevin_flutter_core_android
+  kevin_flutter_core_ios:
+    path: ../packages/kevin_flutter_core/kevin_flutter_core_ios
+  kevin_flutter_in_app_payments_platform_interface:
+    path: ../packages/kevin_flutter_in_app_payments/kevin_flutter_in_app_payments_platform_interface
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Ran into an issue, that ios and android require different callback urls for redirect to work properly. Currently implemented hacky solution to check platform and choose callback url depending on it, though plugin has to be updated to supports specific ios/android callback urls.